### PR TITLE
Improve robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This script was tested on Arch and Ubuntu and has been reported to work on Steam
 
 ### Arch
 
-On Arch, you will need these packages.
+On Arch, you will need these packages:
 
 - `xorg-xwininfo`
 - `xorg-xprop`
@@ -78,7 +78,7 @@ On Arch, you will need these packages.
 
 ### Ubuntu
 
-On Ubuntu, you will need these packages.
+On Ubuntu, you will need these packages:
 
 - `x11-utils`
 - `xdotool`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# What is this for?
+# steamos-fg
+
+## What is this for?
 
 When using the SteamOS compositor, some games start behind the big picture UI and no graphics are displayed. This script forces such games to be shown in the foreground.
 
@@ -11,20 +13,57 @@ Affected games this script fixes include:
  - Mad Max
  - Mirror's Edge (Steam Play)
 
-# Install
+Also games installed as snaps and flatpaks do share this fate and can be fixed by wrapping them with this script.
+
+## Installation
 
 Run the following command:
 
 `sudo curl https://raw.githubusercontent.com/alkazar/steamos-fg/master/steamos-fg -o /usr/local/bin/steamos-fg && sudo chmod a+x /usr/local/bin/steamos-fg`
 
-# Usage
+## Usage
+
+### Steam games
 
 Add `steamos-fg %command%` to the launch options for each game you wish to use this script with.
 
-# Notes
+### Games imported from desktop shortcuts
 
-This script was tested on Arch and reported to work on Ubuntu and SteamOS.
+You can do this is by editing the `.desktop` files and prepending the command with the script path.
 
-On Arch, you will need the `xorg-xwininfo` and `xorg-xprop` packages.
+Example locations of `.desktop` files, here for Debian/Ubuntu:
 
-On Ubuntu, you will need the `x11-utils` package.
+||system-wide|user|
+|---:|:---|:---|
+|**Snap**|`/var/lib/snapd/desktop/applications`|-|
+|**Flatpak**|`/var/lib/flatpak/exports/share/applications`|`${HOME}/.local/share/flatpak/exports/share/applications`|
+
+There is a gotcha however: In its "Add Desktop Shortcut" GUI, Steam ignores all desktop shortcuts where the exacutable has steam in the filename (the arguments are fine).
+
+To fix this, create a link to `steamos-fg` with a different name:
+
+```
+ln -s /usr/local/bin/steamos-fg /usr/local/bin/gameros-fg
+```
+
+Then you can change those `.desktop` files by prepending `/usr/local/bin/gameros-fg` to the value of the `Exec` property:
+
+Snap example:
+
+```
+Exec=/usr/local/bin/gameros-fg env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/xyz.desktop /snap/bin/xyz %U
+```
+
+Flatpak example:
+
+```
+Exec=/usr/local/bin/gameros-fg /usr/bin/flatpak run --branch=stable --arch=x86_64 --command=xyz xyz
+```
+
+## Notes
+
+This script was tested on Arch and Ubuntu and has been reported to work on SteamOS.
+
+On Arch, you will need the `xorg-xwininfo`, `xorg-xprop`, `procps-ng` and `xdotool` packages.
+
+On Ubuntu, you will need the `x11-utils`, `procps` and `xdotool` packages.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@ Exec=/usr/local/bin/gameros-fg /usr/bin/flatpak run --branch=stable --arch=x86_6
 
 This script was tested on Arch and Ubuntu and has been reported to work on SteamOS.
 
-On Arch, you will need the `xorg-xwininfo`, `xorg-xprop`, `procps-ng` and `xdotool` packages.
+## Package dependencies
 
-On Ubuntu, you will need the `x11-utils`, `procps` and `xdotool` packages.
+### Arch
+
+On Arch, you will need these packages.
+
+- `xorg-xwininfo`
+- `xorg-xprop`
+- `xdotool`
+- `procps-ng`
+- `gawk`
+
+### Ubuntu
+
+On Ubuntu, you will need these packages.
+
+- `x11-utils`
+- `xdotool`
+- `procps`
+- `gawk`

--- a/README.md
+++ b/README.md
@@ -84,3 +84,9 @@ On Ubuntu, you will need these packages:
 - `xdotool`
 - `procps`
 - `gawk`
+
+## Alternatives
+
+Instead of this hack, you could fix the problems where they stem from, the `steamos-compositor`.
+
+Have a look at [steamos-compositor-plus](https://github.com/gamer-os/steamos-compositor-plus), which is part of SteamOS alternative [GamerOS](https://gamer-os.github.io/).

--- a/steamos-fg
+++ b/steamos-fg
@@ -17,14 +17,14 @@ apply_steamgame_property() {
         for ID in ${WINDOW_ID}; do
             echo "Handling window with ID $ID"
             # apply STEAM_GAME property to game window so steamos compositor shows game in foreground
-            xprop -display ":0" -id "${ID}" -f STEAM_GAME 32c -set STEAM_GAME 470470 || true
+            xprop -display ${DISPLAY} -id "${ID}" -f STEAM_GAME 32c -set STEAM_GAME 470470 || true
         done
     fi
 }
 
 handle_child_processes() {
     PID=$1
-    WINDOW_ID=$(DISPLAY=:0 xdotool search --pid "${PID}") || true
+    WINDOW_ID=$(xdotool search --pid "${PID}") || true
     apply_steamgame_property "${WINDOW_ID}"
     CHILD_PIDS=$(pgrep -P "${PID}") || true
     for PID in $CHILD_PIDS; do
@@ -34,7 +34,7 @@ handle_child_processes() {
 
 handle_non_steam_windows() {
     # find window with size greater than 99x99 that is not a steam window
-    RESULT=$(xwininfo -display ":0" -root -tree | grep -E "[0-9]{3}x[0-9]{3}" | grep -v \"Steam\"\: | grep -v \"SteamOverlay\"\:) || true
+    RESULT=$(xwininfo -display ${DISPLAY} -root -tree | grep -E "[0-9]{3}x[0-9]{3}" | grep -v \"Steam\"\: | grep -v \"SteamOverlay\"\:) || true
     WINDOW_IDS=$(echo "$RESULT" | awk '{print $1}') || true
     for ID in $WINDOW_IDS; do
         apply_steamgame_property "${ID}"

--- a/steamos-fg
+++ b/steamos-fg
@@ -32,7 +32,7 @@ handle_child_processes() {
     done
 }
 
-handle_non_steam_windows () {
+handle_non_steam_windows() {
     # find window with size greater than 99x99 that is not a steam window
     RESULT=$(xwininfo -display ":0" -root -tree | grep -E "[0-9]{3}x[0-9]{3}" | grep -v \"Steam\"\: | grep -v \"SteamOverlay\"\:) || true
     WINDOW_IDS=$(echo "$RESULT" | awk '{print $1}') || true
@@ -41,7 +41,7 @@ handle_non_steam_windows () {
     done
 }
 
-maintain_foreground() {
+foreground_job() {
     for _ in {1..30}; do
         sleep 1
         handle_child_processes "${PID_GAME}"
@@ -53,10 +53,10 @@ maintain_foreground() {
 exec "$@" > /dev/null &
 PID_GAME=$!
 
-maintain_foreground &
-PID_RESIZER=$!
+foreground_job &
+PID_FOREGROUND_JOB=$!
 
 # wait for game exit
 wait ${PID_GAME}
 # stop resizer if it still is running
-kill ${PID_RESIZER} || true
+kill ${PID_FOREGROUND_JOB} || true

--- a/steamos-fg
+++ b/steamos-fg
@@ -1,15 +1,62 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
-set -e
+# steamos-fg
+# When using the SteamOS compositor, some games start behind the big picture UI and no graphics are displayed.
+# This script forces such games to be shown in the foreground.
+#
+# Usage: steamos-fg [GAME_EXECUTABLE]
 
-exec "$@" & # start game
-sleep 5 # wait a bit for game window
+exec >> "${HOME}/steamos-fg.log"
+exec 2>&1
 
-# find window with size greater than 99x99 that is not a steam window
-RESULT=`xwininfo -display $DISPLAY -root -tree | grep -E "[0-9]{3}x[0-9]{3}" | grep -v \"Steam\"\: | grep -v \"SteamOverlay\"\:`
-WIN_ID=`echo $RESULT | cut -d' ' -f 1`
+set -Eeuo pipefail
 
-# apply STEAM_GAME property to game window so steamos compositor shows game in foreground
-xprop -display $DISPLAY -id $WIN_ID -f STEAM_GAME 32c -set STEAM_GAME 470470
+apply_steamgame_property() {
+    WINDOW_ID=$1
+    if [ ! -z "${WINDOW_ID}" ]; then
+        for ID in ${WINDOW_ID}; do
+            echo "Handling window with ID $ID"
+            # apply STEAM_GAME property to game window so steamos compositor shows game in foreground
+            xprop -display ":0" -id "${ID}" -f STEAM_GAME 32c -set STEAM_GAME 470470 || true
+        done
+    fi
+}
 
-wait # wait for game exit
+handle_child_processes() {
+    PID=$1
+    WINDOW_ID=$(DISPLAY=:0 xdotool search --pid "${PID}") || true
+    apply_steamgame_property "${WINDOW_ID}"
+    CHILD_PIDS=$(pgrep -P "${PID}") || true
+    for PID in $CHILD_PIDS; do
+        handle_child_processes "${PID}"
+    done
+}
+
+handle_non_steam_windows () {
+    # find window with size greater than 99x99 that is not a steam window
+    RESULT=$(xwininfo -display ":0" -root -tree | grep -E "[0-9]{3}x[0-9]{3}" | grep -v \"Steam\"\: | grep -v \"SteamOverlay\"\:) || true
+    WINDOW_IDS=$(echo "$RESULT" | awk '{print $1}') || true
+    for ID in $WINDOW_IDS; do
+        apply_steamgame_property "${ID}"
+    done
+}
+
+maintain_foreground() {
+    for _ in {1..30}; do
+        sleep 1
+        handle_child_processes "${PID_GAME}"
+        handle_non_steam_windows
+    done
+}
+
+# start game
+exec "$@" > /dev/null &
+PID_GAME=$!
+
+maintain_foreground &
+PID_RESIZER=$!
+
+# wait for game exit
+wait ${PID_GAME}
+# stop resizer if it still is running
+kill ${PID_RESIZER} || true

--- a/steamos-fg
+++ b/steamos-fg
@@ -58,5 +58,5 @@ PID_FOREGROUND_JOB=$!
 
 # wait for game exit
 wait ${PID_GAME}
-# stop resizer if it still is running
+# stop foreground_job if it still is running
 kill ${PID_FOREGROUND_JOB} || true


### PR DESCRIPTION
Hi!

I was having troubles with steamos-fg not quite working for some of my use cases.

So what I was trying to achieve is for the script to work for both containerised games (flatpaks/snaps) as well as those troubled Steam games.

Also I was trying to make it more robust against timing variations: Instead of waiting for 5 seconds and performing the fix only once, it now spawns a background process that performs window detection and potentially the fix every second. That background process ends after 30 times. Ample time for any graphic initialisations (and maybe a user-initiated resolution configuration change) to have completed as well as little enough time to not hog resources while actually playing the game.

The original window detection behaviour is retained while at the same time another behaviour has been added that tries to detect windows by PIDs, traversing the process tree spawned by the game executable.

I acknowledge that your `steamos-compositor-plus` (hats off for the effort) project is a more proper solution to these problems, but this approach still is valid for all the use cases where people can't or won't replace their steamos-compositor.

What do you think?